### PR TITLE
Fixed typos in Collaboration/Gradle

### DIFF
--- a/modules/collaboration/_posts/2022-02-09-Gradle.md
+++ b/modules/collaboration/_posts/2022-02-09-Gradle.md
@@ -365,7 +365,7 @@ be changed by simply running in the same folder:
 
 `chmod +x gradlew`
 
-And *then* run `\.gradlew build`
+And *then* run `.\gradlew build`
 
 ### ```.\gradlew build```
 
@@ -373,7 +373,7 @@ And *then* run `\.gradlew build`
 *don't have to have gradle installed on your computer*. The first time you
 run a `.\gradlew` command, the program will automatically install
 the correct version of `gradle` for that project (not to your computer
-as a whole). This is beneficial, because now if you have multipl projects
+as a whole). This is beneficial, because now if you have multiple projects
 on your computer that use different versions of gradle, you don't have to worry
 about it! In fact, you never have to manually install gradle at all.
 


### PR DESCRIPTION
Fixed two small typos in modules/collaboration/_posts/2022-02-09-Gradle.md
- `/.gradlew build` -> `./gradlew build`
- "multipl" -> "multiple"