### PR TITLE
Fixing Typos in SOLID Principles

### DIFF
--- a/modules/design/_posts/2000-01-28-SOLID.md
+++ b/modules/design/_posts/2000-01-28-SOLID.md
@@ -108,10 +108,10 @@ Considering our `Student` class again, what if our software receives a request f
 ```java
 
 public class Student {
-    private boolean isGradStudent();
+    private boolean isGradStudent;
     
     public boolean isGradStudent() {
-        return isGradStudent();
+        return isGradStudent;
     }
     
     public PayInformation getUndergradPayInformation() { 
@@ -352,14 +352,14 @@ public class HumanResources {
         dispersePayment(underGrad, amount);
     }
 
-    public void payUndergradTA(GraduateStudent grad) {
+    public void payGraduateTA(GraduateStudent grad) {
         TAPayment payment = new TAPayment();
         double payAmount = payment.calculatePay(grad);
         dispersePayment(grad, amount);
     }
     ...
 
-    public void payUndergradTA(ProfessionalTA proTA) {
+    public void payProfessionalTA(ProfessionalTA proTA) {
         TAPayment payment = new TAPayment();
         double payAmount = payment.calculatePay(proTA);
         dispersePayment(proTA, amount);


### PR DESCRIPTION
I noticed what I think are typos in the SOLID principles page. I think the Open-Closed Principle code is supposed to have a boolean isGradStudent. I think the Dependency Inversion code is supposed to have payXTA for each type of TA and not three payUndergrad TA. 